### PR TITLE
Catch rust panics to not propagate undefined behavior

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,6 @@
+use failure::Error;
+use std::error;
+
 /// Errors that occur when converting Rust's text data to a format collectd expects
 #[derive(Fail, Debug)]
 pub enum ArrayError {
@@ -29,3 +32,17 @@ pub struct NotImplemented;
 #[derive(Fail, Debug)]
 #[fail(display = "Unable to retrieve rate (see collectd logs for additional details)")]
 pub struct CacheRateError;
+
+/// Errors that occur on the boundary between collectd and a plugin
+pub enum FfiError {
+    /// Represents a plugin that panicked. A plugin that panics has a logic bug that should be
+    /// fixed so that the plugin can better log and recover, else collectd decides
+    Panic,
+
+    /// An error from the plugin. This is a "normal" error that the plugin has caught. Like if the
+    /// database is down and the plugin has the proper error mechanisms
+    Plugin(Error),
+
+    /// An error ocurred outside the path of a plugin
+    Collectd(Box<error::Error>),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub use api::{
     CollectdLoggerBuilder, ConfigItem, ConfigValue, LogLevel, Value, ValueList, ValueListBuilder,
     ValueReport,
 };
-pub use errors::{ArrayError, SubmitError};
+pub use errors::{ArrayError, FfiError, SubmitError};
 pub use plugins::{
     Plugin, PluginCapabilities, PluginManager, PluginManagerCapabilities, PluginRegistration,
 };


### PR DESCRIPTION
This PR catches panics from any `Plugin` function and a subset from `PluginManager` because

> It is currently undefined behavior to unwind from Rust code into foreign code, so [catching panics] is useful when Rust is called from another language (normally C). This can run arbitrary Rust code, capturing a panic and allowing a graceful handling of the error. [[source]](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html)

This is a potential breaking change as a `Plugin` must now implement `UnwindSafe + RefUnwindSafe` in addition to `Send + Sync`. In reality, most implementations should remain unchanged.

The original impetus for this change was a silly mistake in a downstream plugin:

```rust
let a = Instant::now();
// ...
a.duration_since(Instant::now()); // will panic!
```

This caused a SIGABRT in collectd 😢 

Now this will be caught and gracefully logged. Collectd will then determine the correct behavior (backoff, retry, or quit).

Closes #2