### PR TITLE
Delegate error logging initially to rust

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -62,8 +62,8 @@ grep_test 'collectd logging configuration: Some' /var/lib/collectd/log
 grep_test 'write_logrs: write_logrs: rust logging configuration: Some' /var/lib/collectd/log
 grep_test 'write_logrs: write_logrs: flushing: timeout: no timeout, identifier: no identifier' /var/lib/collectd/log
 grep_test 'write_logrs: write_logrs: yes drop is called' /var/lib/collectd/log
-grep_test 'read error: bailing;' /var/lib/collectd/log
+grep_test 'myerror: collectd_plugin::api::logger: read error: bailing;' /var/lib/collectd/log
 grep_test 'read-function of plugin `myerror'"'"' failed.' /var/lib/collectd/log
-grep_test 'plugin has panicked, so a logic oversight exists' /var/lib/collectd/log
+grep_test 'myerror: collectd_plugin::api::logger: plugin has panicked, so a logic oversight exists' /var/lib/collectd/log
 
 exit $?

--- a/src/api/logger.rs
+++ b/src/api/logger.rs
@@ -200,6 +200,17 @@ impl CollectdLogger {
     }
 }
 
+/// Given an error message that must be logged, we first see if rust's logging mechanism has been
+/// setup, as that will contain user preferences in regards to output's format. If rust won't log
+/// it, delegate to directly collectd.
+pub fn delegate_log(msg: &str) {
+    if log_enabled!(Level::Error) {
+        error!("{}", msg);
+    } else {
+        collectd_log(LogLevel::Error, msg);
+    }
+}
+
 /// Sends message and log level to collectd. This bypasses any configuration setup via
 /// [`CollectdLoggerBuilder`], so collectd configuration soley determines if a level is logged
 /// and where it is delivered. Messages that are too long are truncated (1024 was the max length as

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,7 @@ use std::slice;
 use std::str::Utf8Error;
 
 pub use self::cdtime::{nanos_to_collectd, CdTime};
-pub use self::logger::{collectd_log, CollectdLoggerBuilder, LogLevel};
+pub use self::logger::{collectd_log, delegate_log, CollectdLoggerBuilder, LogLevel};
 pub use self::oconfig::{ConfigItem, ConfigValue};
 
 mod cdtime;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,9 @@ impl fmt::Display for ConfigError {
             ConfigError::UnknownType(type_) => {
                 write!(f, "unknown value ({}) for config enum", type_)
             }
-            ConfigError::StringDecode(ref _e) => write!(f, "unable to convert config string to utf8"),
+            ConfigError::StringDecode(ref _e) => {
+                write!(f, "unable to convert config string to utf8")
+            }
         }
     }
 }
@@ -194,4 +196,8 @@ pub enum FfiError {
 
     /// An error ocurred outside the path of a plugin
     Collectd(Box<error::Error>),
+
+    UnknownSeverity(i32),
+
+    MultipleConfig,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate env_logger;
+#[macro_use]
 extern crate log;
 
 #[cfg(feature = "serde")]
@@ -128,9 +129,9 @@ mod errors;
 mod plugins;
 
 pub use api::{
-    collectd_log, empty_to_none, from_array, get_default_interval, nanos_to_collectd, CdTime,
-    CollectdLoggerBuilder, ConfigItem, ConfigValue, LogLevel, Value, ValueList, ValueListBuilder,
-    ValueReport,
+    collectd_log, delegate_log, empty_to_none, from_array, get_default_interval, nanos_to_collectd,
+    CdTime, CollectdLoggerBuilder, ConfigItem, ConfigValue, LogLevel, Value, ValueList,
+    ValueListBuilder, ValueReport,
 };
 pub use errors::{ArrayError, CollectdUtf8Error, ConfigError, FfiError, ReceiveError, SubmitError};
 pub use plugins::{

--- a/tests/sample.rs
+++ b/tests/sample.rs
@@ -12,7 +12,9 @@ mod tt {
             "myplugin"
         }
 
-        fn plugins(_config: Option<&[ConfigItem]>) -> Result<PluginRegistration, Box<error::Error>> {
+        fn plugins(
+            _config: Option<&[ConfigItem]>,
+        ) -> Result<PluginRegistration, Box<error::Error>> {
             collectd_log_raw!(LogLevel::Info, b"test %d\0", 10);
             Ok(PluginRegistration::Multiple(vec![]))
         }


### PR DESCRIPTION
This is so any error that arises from a panic or from bad input from collectd will be logged in the same format as regular logging statements from the plugin.