### PR TITLE
Translate i8 to cross platform c_char

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+
+    # On aarch64 machines, c_char = u8 instead of i8
+    - rust: stable
+      env: CROSS_TARGET=aarch64-unknown-linux-gnu COLLECTD_VERSION=5.5
+
+    # These are the full blown integration tests
     - rust: stable
       env: UBUNTU_VERSION=14.04 COLLECTD_VERSION=5.4
     - rust: stable
@@ -24,5 +30,6 @@ matrix:
 script:
   - COLLECTD_VERSION=5.5 cargo build --all
   - if [ ! $TRAVIS_RUST_VERSION = "1.24.1" ]; then COLLECTD_VERSION=5.5 cargo test --all; fi;
+  - if [ ! -z $CROSS_TARGET ]; then cargo install && cross test --target aarch64-unknown-linux-gnu; fi;
   - if [ ! -z $UBUNTU_VERSION ]; then docker build -t collectd-rust-plugin --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg COLLECTD_VERSION=${COLLECTD_VERSION} .; fi;
   - if [ ! -z $UBUNTU_VERSION ]; then docker run -ti collectd-rust-plugin bash -c "cd /tmp && COLLECTD_VERSION=${COLLECTD_VERSION} ci/test.sh"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ matrix:
 script:
   - COLLECTD_VERSION=5.5 cargo build --all
   - if [ ! $TRAVIS_RUST_VERSION = "1.24.1" ]; then COLLECTD_VERSION=5.5 cargo test --all; fi;
-  - if [ ! -z $CROSS_TARGET ]; then cargo install && cross test --target aarch64-unknown-linux-gnu; fi;
+  - if [ ! -z $CROSS_TARGET ]; then cargo install cross && cross test --target aarch64-unknown-linux-gnu; fi;
   - if [ ! -z $UBUNTU_VERSION ]; then docker build -t collectd-rust-plugin --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg COLLECTD_VERSION=${COLLECTD_VERSION} .; fi;
   - if [ ! -z $UBUNTU_VERSION ]; then docker run -ti collectd-rust-plugin bash -c "cd /tmp && COLLECTD_VERSION=${COLLECTD_VERSION} ci/test.sh"; fi;

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = [ "COLLECTD_VERSION" ]

--- a/src/api/logger.rs
+++ b/src/api/logger.rs
@@ -284,14 +284,14 @@ macro_rules! collectd_log_raw {
         let level: $crate::LogLevel = $lvl;
         let level = level as i32;
         unsafe {
-            $crate::bindings::plugin_log(level, ($fmt).as_ptr() as *const i8);
+            $crate::bindings::plugin_log(level, ($fmt).as_ptr() as *const ::std::os::raw::c_char);
         }
     });
     ($lvl:expr, $fmt:expr, $($arg:expr),*) => ({
         let level: $crate::LogLevel = $lvl;
         let level = level as i32;
         unsafe {
-            $crate::bindings::plugin_log(level, ($fmt).as_ptr() as *const i8, $($arg)*);
+            $crate::bindings::plugin_log(level, ($fmt).as_ptr() as *const ::std::os::raw::c_char, $($arg)*);
         }
     });
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -341,13 +341,13 @@ impl<'a> ValueListBuilder<'a> {
             .list
             .plugin_instance
             .map(|x| to_array_res(x).map_err(|e| SubmitError::Field("plugin_instance", e)))
-            .unwrap_or_else(|| Ok([0i8; ARR_LENGTH]))?;
+            .unwrap_or_else(|| Ok([0 as c_char; ARR_LENGTH]))?;
 
         let type_instance = self
             .list
             .type_instance
             .map(|x| to_array_res(x).map_err(|e| SubmitError::Field("type_instance", e)))
-            .unwrap_or_else(|| Ok([0i8; ARR_LENGTH]))?;
+            .unwrap_or_else(|| Ok([0 as c_char; ARR_LENGTH]))?;
 
         let host = self
             .list
@@ -362,7 +362,7 @@ impl<'a> ValueListBuilder<'a> {
                 // submitted and would cause garbage to be read (and thus could have very much
                 // unintended side effects)
                 if cfg!(collectd57) {
-                    Ok([0i8; ARR_LENGTH])
+                    Ok([0 as c_char; ARR_LENGTH])
                 } else {
                     unsafe { Ok(hostname_g) }
                 }
@@ -429,7 +429,7 @@ fn to_array_res(s: &str) -> Result<[c_char; ARR_LENGTH], ArrayError> {
 /// Turns a fixed size character array into string slice, if possible
 pub fn from_array(s: &[c_char; ARR_LENGTH]) -> Result<&str, Utf8Error> {
     unsafe {
-        let a = s as *const [i8; ARR_LENGTH] as *const i8;
+        let a = s as *const [c_char; ARR_LENGTH] as *const c_char;
         CStr::from_ptr(a).to_str()
     }
 }


### PR DESCRIPTION
Compiling for aarch64-unknown-linux-gnu failed due to `c_char` being an `u8` on those platform. This PR fixes the issue by consistently using `c_char`.