### PR TITLE
Add COLLECTD_PATH environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,18 @@ matrix:
     - rust: beta
     - rust: nightly
 
+    - rust: stable
+      env: COLLECTD_PATH=./collectd
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - llvm-5.0-dev
+            - clang-5.0
+            - libclang-5.0-dev
+
     # On aarch64 machines, c_char = u8 instead of i8
     - rust: stable
       env: CROSS_TARGET=aarch64-unknown-linux-gnu COLLECTD_VERSION=5.5
@@ -27,9 +39,13 @@ matrix:
     - rust: stable
       env: UBUNTU_VERSION=18.10 COLLECTD_VERSION=5.7
 
+before_install:
+  - if [ ! -z $COLLECTD_PATH ]; then sudo apt-get update && sudo apt-get install -qq --no-install-recommends autotools-dev libltdl-dev && git clone https://github.com/collectd/collectd.git $COLLECTD_PATH; fi
+
 script:
   - COLLECTD_VERSION=5.5 cargo build --all
   - if [ ! $TRAVIS_RUST_VERSION = "1.24.1" ]; then COLLECTD_VERSION=5.5 cargo test --all; fi;
+  - if [ ! -z $COLLECTD_PATH ]; then cargo test --features bindgen --all; fi;
   - if [ ! -z $CROSS_TARGET ]; then cargo install cross && cross test --target aarch64-unknown-linux-gnu; fi;
   - if [ ! -z $UBUNTU_VERSION ]; then docker build -t collectd-rust-plugin --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg COLLECTD_VERSION=${COLLECTD_VERSION} .; fi;
   - if [ ! -z $UBUNTU_VERSION ]; then docker run -ti collectd-rust-plugin bash -c "cd /tmp && COLLECTD_VERSION=${COLLECTD_VERSION} ci/test.sh"; fi;

--- a/README.md
+++ b/README.md
@@ -132,8 +132,11 @@ bindgen = ["collectd-plugin/bindgen"]
 default = []
 ```
 
-- A collectd version is required. You can specify environment variable `COLLECTD_VERSION` as `5.4`, `5.5`, or `5.7`, or rely on `collectd-rust-plugin` auto detecting the version by executing `collectd -h`.
-- The bindgen feature is optional (it will re-compute the Rust bindings from C code, which shouldn't be necessary). Make sure you have an appropriate version of clang installed and `collectd-dev`
+- A collectd version is required to build. There are several ways one can specify it:
+  - Via environment variable: `COLLECTD_VERSION` = `5.4`, `5.5`, or `5.7`.
+  - Via environment variable: `COLLECTD_PATH` points to the [root git directory for collectd](https://github.com/collectd/collectd). This option makes the most sense when coupled with the `bindgen` feature.
+  - Auto detection by executing `collectd -h`.
+- The bindgen feature is optional (it will re-compute the Rust bindings from C code, which shouldn't be necessary). Make sure you have an appropriate version of clang installed and `collectd-dev` (if not using `COLLECTD_PATH`)
 - collectd expects plugins to not be prefixed with `lib`, so `cp target/debug/libmyplugin.so /usr/lib/collectd/myplugin.so`
 - Add `LoadPlugin myplugin` to collectd.conf
 

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,4 +1,8 @@
-#ifdef COLLECTD_54
+#ifdef COLLECTD_PATH
+    #include <liboconfig/oconfig.h>
+    #include <daemon/plugin.h>
+    #include <daemon/utils_cache.h>
+#elif COLLECTD_54
     #include <collectd/core/plugin.h>
     #include <collectd/core/utils_cache.h>
 #else


### PR DESCRIPTION
If one builds collectd from source, this is no way for `collectd-rust-plugin` to leverage that source -- until now. Set `COLLECTD_PATH` environment variable to the root of the collectd git repo and use the `bindgen` feature when building.