### PR TITLE
Exclude all env_logger features by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = "0.4.0"
 bitflags = "1.0"
 memchr = "2"
 log = "0.4"
-env_logger = "0.7"
+env_logger = { version =  "0.7", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -42,6 +42,7 @@ rustversion = "1.0"
 
 [features]
 stub = []
+regex_log_filter = ["env_logger/regex"]
 default = ["serde"]
 
 [[example]]

--- a/src/api/logger.rs
+++ b/src/api/logger.rs
@@ -84,28 +84,25 @@ impl CollectdLoggerBuilder {
         self
     }
 
-    /// See
-    /// [`env_logger::Builder::filter_level`](https://docs.rs/env_logger/0.5.13/env_logger/struct.Builder.html#method.filter_level)
+    /// See [`env_logger::filter::Builder::filter_level`](https://docs.rs/env_logger/0.7.1/env_logger/filter/struct.Builder.html#method.filter_level)
     pub fn filter_level(&mut self, level: LevelFilter) -> &mut Self {
         self.filter.filter_level(level);
         self
     }
 
-    /// See:
-    /// [`env_logger::Builder::filter_module`](https://docs.rs/env_logger/0.5.13/env_logger/struct.Builder.html#method.filter_module)
+    /// See: [`env_logger::filter::Builder::filter_module`](https://docs.rs/env_logger/0.7.1/env_logger/filter/struct.Builder.html#method.filter_module)
     pub fn filter_module(&mut self, module: &str, level: LevelFilter) -> &mut Self {
         self.filter.filter_module(module, level);
         self
     }
 
-    /// See:
-    /// [`env_logger::Builder::filter`](https://docs.rs/env_logger/0.5.13/env_logger/struct.Builder.html#method.filter)
+    /// See: [`env_logger::filter::Builder::filter`](https://docs.rs/env_logger/0.7.1/env_logger/filter/struct.Builder.html#method.filter)
     pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
         self.filter.filter(module, level);
         self
     }
 
-    /// See: [`env_logger::Builder::parse`](https://docs.rs/env_logger/0.5.13/env_logger/struct.Builder.html#method.parse)
+    /// See: [`env_logger::filter::Builder::parse`](https://docs.rs/env_logger/0.7.1/env_logger/filter/struct.Builder.html#method.parse)
     pub fn parse(&mut self, filters: &str) -> &mut Self {
         self.filter.parse(filters);
         self


### PR DESCRIPTION
The only env_logger feature related to filtering is the `regex` feature,
so that feature can be enabled through the `regex_log_filter` feature.
The rest of disabled to keep dependencies to a minimum