### PR TITLE
Call the initialize method before creating plugins

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -220,11 +220,7 @@ fn register_all_plugins<T: PluginManager>(config: Option<&[ConfigItem<'_>]>) -> 
 }
 
 pub fn plugin_init<T: PluginManager>(config_seen: &AtomicBool) -> c_int {
-    let mut result = if !config_seen.swap(true, Ordering::Relaxed) {
-        register_all_plugins::<T>(None)
-    } else {
-        0
-    };
+    let mut result = 0;
 
     let capabilities = T::capabilities();
     if capabilities.intersects(PluginManagerCapabilities::INIT) {
@@ -236,6 +232,10 @@ pub fn plugin_init<T: PluginManager>(config_seen: &AtomicBool) -> c_int {
             result = -1;
             log_err("init", e);
         }
+    }
+
+    if result == 0 && !config_seen.swap(true, Ordering::Relaxed) {
+        result = register_all_plugins::<T>(None);
     }
 
     result


### PR DESCRIPTION
Initialization called too late for plugins. If I want to use shared value like `OnceCell` I can't do that in plugin's `new` method, because `initialize` called after all plugins created only and I have to add a special initialization workaround to other plugin's methods.

This PR changes the order when `initialize` method called to let plugins have access to really initialized shared data.