### PR TITLE
Update dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ travis-ci = { repository = "nickbabcock/collectd-rust-plugin" }
 
 [build-dependencies]
 regex = "1"
-bindgen = { version = "0.55.1", optional = true }
+bindgen = { version = "0.58.1", optional = true }
 
 [dependencies]
 chrono = "0.4.0"
 bitflags = "1.0"
 memchr = "2"
 log = "0.4"
-env_logger = { version =  "0.7", default-features = false }
+env_logger = { version =  "0.8", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -33,7 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_test = "1.0"
 criterion = "0.3"
 log = { version = "0.4", features = ["serde"] }
-itertools = "0.9"
+itertools = "0.10"
 num_cpus = "1.0"
 failure = "0.1.3"
 libc = "0.2"


### PR DESCRIPTION
Bindgen didn't change the output format so no need to regenerate
bindings