### PR TITLE
Guard slice with null and length checks

### DIFF
--- a/src/api/oconfig.rs
+++ b/src/api/oconfig.rs
@@ -71,22 +71,28 @@ impl<'a> ConfigItem<'a> {
             .to_str()
             .map_err(ConfigError::StringDecode)?;
 
-        let values: Result<Vec<ConfigValue<'b>>, ConfigError> =
-            slice::from_raw_parts(item.values, item.values_num as usize)
+        let values = if !item.values.is_null() {
+            slice::from_raw_parts(item.values, item.values_num.max(0) as usize)
                 .iter()
                 .map(|x| ConfigValue::from(x))
-                .collect();
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            Vec::new()
+        };
 
-        let children: Result<Vec<ConfigItem<'b>>, ConfigError> =
-            slice::from_raw_parts(item.children, item.children_num as usize)
+        let children = if !item.children.is_null() {
+            slice::from_raw_parts(item.children, item.children_num.max(0) as usize)
                 .iter()
                 .map(|x| ConfigItem::from(x))
-                .collect();
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            Vec::new()
+        };
 
         Ok(ConfigItem {
             key,
-            values: values?,
-            children: children?,
+            values,
+            children,
         })
     }
 }


### PR DESCRIPTION
Tests started to fail with

> panic hook error: plugin panicked: (library/core/src/panicking.rs: 156): unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`

It's not clear to me what changed to cause this (a bit of trial and error showed the root cause being a `null` "children" or "values" in an `oconfig_item_t`).

This commit fixes the issue by guarding slice creation with null and length checks.