### PR TITLE
Add armv7-unknown-linux-gnueabihf to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,20 @@ jobs:
         build:
         - stable
         - collectd-head
-        - aarch64
+        - armv7-unknown-linux-gnueabihf
+        - aarch64-unknown-linux-gnu
         - regen
         include:
         - build: stable
           os: 'ubuntu-latest'
         - build: collectd-head
           os: 'ubuntu-latest'
-        - build: aarch64
-          target: aarch64-unknown-linux-gnu
+        - build: aarch64-unknown-linux-gnu
           os: 'ubuntu-latest'
+          target: aarch64-unknown-linux-gnu
+        - build: armv7-unknown-linux-gnueabihf
+          os: 'ubuntu-latest'
+          target: armv7-unknown-linux-gnueabihf
         - build: regen
           os: 'ubuntu-latest'
     steps:
@@ -41,7 +45,7 @@ jobs:
         components: rust-src
 
     - name: Use Cross
-      if: matrix.build == 'aarch64'
+      if: matrix.target != ''
       run: |
         cargo install cross
         echo "CARGO=cross" >> $GITHUB_ENV
@@ -57,8 +61,12 @@ jobs:
         git clone https://github.com/collectd/collectd /tmp/collectd
         echo "COLLECTD_PATH=/tmp/collectd" >> $GITHUB_ENV
         echo "FEATURES=--features bindgen" >> $GITHUB_ENV
+
+    - name: build
+      run: ${{ env.CARGO }} build --examples $FEATURES --verbose $TARGET
   
     - name: tests
+      if: matrix.build != 'armv7-unknown-linux-gnueabihf' # layout tests fail
       run: ${{ env.CARGO }} test $FEATURES --verbose $TARGET
 
     - name: test benchmarks


### PR DESCRIPTION
Checking out v0.14.0, `aarch64-unknown-linux-gnu` builds, but `armv7-unknown-linux-gnueabihf` doesn't, so this adds the target to CI so we don't regress.

Ref: #112