### PR TITLE
Remove env_logger from logging system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ chrono = "0.4.0"
 bitflags = "2.4"
 memchr = "2"
 log = "0.4"
-env_logger = { version =  "0.11", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 libc = { version = "0.2" }
 
@@ -34,6 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_test = "1.0"
 criterion = "0.5"
 log = { version = "0.4", features = ["serde"] }
+env_logger = "0.11"
 num_cpus = "1.0"
 anyhow = "1.0"
 libc = "0.2"
@@ -42,7 +42,6 @@ doc-comment = "0.3"
 
 [features]
 stub = []
-regex_log_filter = ["env_logger/regex"]
 default = ["serde"]
 
 [[example]]
@@ -69,6 +68,10 @@ crate-type = ["cdylib"]
 
 [[example]]
 name = "write_graphite"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "env_logger"
 crate-type = ["cdylib"]
 
 [[bench]]

--- a/examples/env_logger.rs
+++ b/examples/env_logger.rs
@@ -1,0 +1,80 @@
+use collectd_plugin::{
+    collectd_plugin, CollectdLogger, CollectdLoggerBuilder, ConfigItem, Plugin, PluginCapabilities,
+    PluginManager, PluginRegistration, ValueList,
+};
+use log::{debug, info};
+use std::error;
+
+#[derive(Default)]
+struct MyPlugin;
+
+impl PluginManager for MyPlugin {
+    fn name() -> &'static str {
+        "filtered_logging"
+    }
+
+    fn plugins(
+        _config: Option<&[ConfigItem<'_>]>,
+    ) -> Result<PluginRegistration, Box<dyn error::Error>> {
+        // APPROACH: Use env_logger for filtering, forward to CollectdLogger
+        //
+        // Users can configure with: RUST_LOG=debug,my_module=trace,other_crate=warn
+
+        let global_filter_level = log::LevelFilter::Info;
+        let env_filter = env_logger::Builder::from_default_env()
+            .filter_level(global_filter_level)
+            .build();
+
+        let collectd_logger = CollectdLoggerBuilder::new().prefix_plugin::<Self>().build();
+
+        let filtered_logger = FilteredCollectdLogger {
+            env_logger: env_filter,
+            collectd_logger,
+        };
+
+        log::set_max_level(global_filter_level);
+        log::set_boxed_logger(Box::new(filtered_logger))?;
+        Ok(PluginRegistration::Single(Box::new(MyPlugin)))
+    }
+}
+
+/// A logger that uses env_logger's filtering but outputs only to collectd
+struct FilteredCollectdLogger {
+    env_logger: env_logger::Logger,
+    collectd_logger: CollectdLogger,
+}
+
+impl log::Log for FilteredCollectdLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        self.env_logger.enabled(metadata)
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.collectd_logger.log(record);
+        }
+    }
+
+    fn flush(&self) {
+        self.collectd_logger.flush();
+    }
+}
+
+impl Plugin for MyPlugin {
+    fn capabilities(&self) -> PluginCapabilities {
+        PluginCapabilities::WRITE
+    }
+
+    fn write_values(&self, list: ValueList<'_>) -> Result<(), Box<dyn error::Error>> {
+        // This will respect the RUST_LOG filtering
+        debug!(
+            "Processing {} values from {}",
+            list.values.len(),
+            list.plugin
+        );
+        info!("Received data from plugin: {}", list.plugin);
+        Ok(())
+    }
+}
+
+collectd_plugin!(MyPlugin);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub use self::cdtime::CdTime;
-pub use self::logger::{collectd_log, log_err, CollectdLoggerBuilder, LogLevel};
+pub use self::logger::{collectd_log, log_err, CollectdLogger, CollectdLoggerBuilder, LogLevel};
 pub use self::oconfig::{ConfigItem, ConfigValue};
 use crate::bindings::{
     data_set_t, meta_data_add_boolean, meta_data_add_double, meta_data_add_signed_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ mod errors;
 mod plugins;
 
 pub use crate::api::{
-    collectd_log, CdTime, CollectdLoggerBuilder, ConfigItem, ConfigValue, LogLevel, MetaValue,
-    Value, ValueList, ValueListBuilder, ValueReport,
+    collectd_log, CdTime, CollectdLogger, CollectdLoggerBuilder, ConfigItem, ConfigValue, LogLevel,
+    MetaValue, Value, ValueList, ValueListBuilder, ValueReport,
 };
 pub use crate::errors::{CacheRateError, ConfigError, ReceiveError, SubmitError};
 pub use crate::plugins::{


### PR DESCRIPTION
Forcing env_logger module for all users seems a bit heavy handed when advanced filtering can be punted onto the user.

- Removed env_logger as direct dependency
- Added `CollectdLoggerBuilder::build` to enable forwarding patterns
- Backwards compatibility has been maintained for users not needing advanced filtering.

Breaking changes:

The following env_logger-specific methods were removed

- `.parse()`
- `.filter_module()`
- `.filter_level()`

**Before**
```rust
CollectdLoggerBuilder::new()
    .parse("debug,my_module=trace")
    .filter_module("my_module2", LevelFilter::Trace)
    .try_init()?;
```

**After:**
```rust
// Use env_logger for filtering, forward to CollectdLogger
let env_filter = env_logger::Builder::from_default_env()
    .parse("debug,my_module=trace")
    .filter_module("my_module2", LevelFilter::Trace)
    .build();

let collectd_logger = CollectdLoggerBuilder::new()
    .prefix_plugin::<Self>()
    .build();

let filtered_logger = FilteredLogger {
    env_logger: env_filter,
    collectd_logger,
};

log::set_boxed_logger(Box::new(filtered_logger))?;

struct FilteredCollectdLogger {
    env_logger: env_logger::Logger,
    collectd_logger: CollectdLogger,
}

impl log::Log for FilteredCollectdLogger {
    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
        self.env_logger.enabled(metadata)
    }

    fn log(&self, record: &log::Record<'_>) {
        if self.env_logger.enabled(record.metadata()) {
            self.collectd_logger.log(record);
        }
    }

    fn flush(&self) {
        self.collectd_logger.flush();
    }
}
```